### PR TITLE
fix typo SSHHostPort Config-not-required.mdx

### DIFF
--- a/.web-docs/components/builder/qemu/README.md
+++ b/.web-docs/components/builder/qemu/README.md
@@ -347,6 +347,7 @@ necessary for this build to succeed and can be found further down the page.
       [ "-netdev", "user,hostfwd=tcp::{{ .SSHHostPort }}-:22,id=forward"],
       [ "-device", "virtio-net,netdev=forward,id=net0"]
     ]
+  ```
   
   In JSON:
   ```json

--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -478,6 +478,7 @@ type Config struct {
 	//     [ "-netdev", "user,hostfwd=tcp::{{ .SSHHostPort }}-:22,id=forward"],
 	//     [ "-device", "virtio-net,netdev=forward,id=net0"]
 	//   ]
+	// ```
 	//
 	// In JSON:
 	// ```json

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -247,6 +247,7 @@
       [ "-netdev", "user,hostfwd=tcp::{{ .SSHHostPort }}-:22,id=forward"],
       [ "-device", "virtio-net,netdev=forward,id=net0"]
     ]
+  ```
   
   In JSON:
   ```json


### PR DESCRIPTION
Code blocks for HCL2 and JSON in SSHHostPort exemple were not separated